### PR TITLE
Add sbt action to run scalastyle

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,7 @@ ThisBuild / version      := "0.0.1-SNAPSHOT"
 ThisBuild / scalaVersion := scalaV
 
 lazy val commonSettings = Seq(
+  scalastyleConfig := file("project/scalastyle_config.xml")
 )
 
 lazy val root = (project in file("."))

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")


### PR DESCRIPTION
Allows running `sbt scalastyle` from CLI, there are also integrations with IntelliJ etc.

I will ask guys from https://github.com/lokkju/github-action-sbt to update supported versions. If they do, we can drop setting up scalastyle in our workflow and just run the action instead.

References #2