### PR TITLE
Update scalastyle rules

### DIFF
--- a/.github/workflows/code_quality.yaml
+++ b/.github/workflows/code_quality.yaml
@@ -27,4 +27,4 @@ jobs:
         with:
           args: -O scalastyle_2.12-1.0.0-batch.jar https://repo1.maven.org/maven2/org/scalastyle/scalastyle_2.12/1.0.0/scalastyle_2.12-1.0.0-batch.jar
       - name: Run Scalastyle
-        run: java -jar scalastyle_2.12-1.0.0-batch.jar --config project/scalastyle_config.xml ./prinz/src/main/scala/
+        run: java -jar scalastyle_2.12-1.0.0-batch.jar --config project/scalastyle_config.xml ./

--- a/project/scalastyle_config.xml
+++ b/project/scalastyle_config.xml
@@ -1,142 +1,123 @@
 <scalastyle commentFilter="enabled">
   <name>Scalastyle standard configuration</name>
-  <check level="warning" class="org.scalastyle.file.FileTabChecker" enabled="true"></check>
-  <check level="warning" class="org.scalastyle.file.FileLengthChecker" enabled="true">
+  <check level="error" class="org.scalastyle.file.FileTabChecker" enabled="true"></check>
+  <check level="error" class="org.scalastyle.file.FileLengthChecker" enabled="true">
     <parameters>
       <parameter name="maxFileLength"><![CDATA[800]]></parameter>
     </parameters>
   </check>
-  <check level="warning" class="org.scalastyle.file.HeaderMatchesChecker" enabled="true">
-    <parameters>
-      <parameter name="header"><![CDATA[// Copyright (C) 2011-2012 the original author or authors.
-// See the LICENCE.txt file distributed with this work for additional
-// information regarding copyright ownership.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.]]></parameter>
-    </parameters>
-  </check>
-  <check level="warning" class="org.scalastyle.scalariform.SpacesAfterPlusChecker" enabled="true"></check>
-  <check level="warning" class="org.scalastyle.file.WhitespaceEndOfLineChecker" enabled="true"></check>
-  <check level="warning" class="org.scalastyle.scalariform.SpacesBeforePlusChecker" enabled="true"></check>
-  <check level="warning" class="org.scalastyle.file.FileLineLengthChecker" enabled="true">
+  <check level="error" class="org.scalastyle.scalariform.SpacesAfterPlusChecker" enabled="true"></check>
+  <check level="error" class="org.scalastyle.file.WhitespaceEndOfLineChecker" enabled="true"></check>
+  <check level="error" class="org.scalastyle.scalariform.SpacesBeforePlusChecker" enabled="true"></check>
+  <check level="error" class="org.scalastyle.file.FileLineLengthChecker" enabled="true">
     <parameters>
       <parameter name="maxLineLength"><![CDATA[160]]></parameter>
       <parameter name="tabSize"><![CDATA[4]]></parameter>
     </parameters>
   </check>
-  <check level="warning" class="org.scalastyle.scalariform.ClassNamesChecker" enabled="true">
+  <check level="error" class="org.scalastyle.scalariform.ClassNamesChecker" enabled="true">
     <parameters>
       <parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter>
     </parameters>
   </check>
-  <check level="warning" class="org.scalastyle.scalariform.ObjectNamesChecker" enabled="true">
+  <check level="error" class="org.scalastyle.scalariform.ObjectNamesChecker" enabled="true">
     <parameters>
       <parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter>
     </parameters>
   </check>
-  <check level="warning" class="org.scalastyle.scalariform.PackageObjectNamesChecker" enabled="true">
+  <check level="error" class="org.scalastyle.scalariform.PackageObjectNamesChecker" enabled="true">
     <parameters>
       <parameter name="regex"><![CDATA[^[a-z][A-Za-z]*$]]></parameter>
     </parameters>
   </check>
-  <check level="warning" class="org.scalastyle.scalariform.EqualsHashCodeChecker" enabled="true"></check>
-  <check level="warning" class="org.scalastyle.scalariform.IllegalImportsChecker" enabled="true">
+  <check level="error" class="org.scalastyle.scalariform.EqualsHashCodeChecker" enabled="true"></check>
+  <check level="error" class="org.scalastyle.scalariform.IllegalImportsChecker" enabled="true">
     <parameters>
       <parameter name="illegalImports"><![CDATA[sun._,java.awt._]]></parameter>
     </parameters>
   </check>
-  <check level="warning" class="org.scalastyle.scalariform.ParameterNumberChecker" enabled="true">
+  <check level="error" class="org.scalastyle.scalariform.ParameterNumberChecker" enabled="true">
     <parameters>
       <parameter name="maxParameters"><![CDATA[8]]></parameter>
     </parameters>
   </check>
-  <check level="warning" class="org.scalastyle.scalariform.MagicNumberChecker" enabled="true">
+  <check level="error" class="org.scalastyle.scalariform.MagicNumberChecker" enabled="true">
     <parameters>
       <parameter name="ignore"><![CDATA[-1,0,1,2,3]]></parameter>
     </parameters>
   </check>
-  <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceBeforeLeftBracketChecker" enabled="true"></check>
-  <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceAfterLeftBracketChecker" enabled="true"></check>
-  <check level="warning" class="org.scalastyle.scalariform.ReturnChecker" enabled="true"></check>
-  <check level="warning" class="org.scalastyle.scalariform.NullChecker" enabled="true"></check>
-  <check level="warning" class="org.scalastyle.scalariform.NoCloneChecker" enabled="true"></check>
-  <check level="warning" class="org.scalastyle.scalariform.NoFinalizeChecker" enabled="true"></check>
-  <check level="warning" class="org.scalastyle.scalariform.CovariantEqualsChecker" enabled="true"></check>
-  <check level="warning" class="org.scalastyle.scalariform.StructuralTypeChecker" enabled="true"></check>
-  <check level="warning" class="org.scalastyle.file.RegexChecker" enabled="true">
+  <check level="error" class="org.scalastyle.scalariform.NoWhitespaceBeforeLeftBracketChecker" enabled="true"></check>
+  <check level="error" class="org.scalastyle.scalariform.NoWhitespaceAfterLeftBracketChecker" enabled="true"></check>
+  <check level="error" class="org.scalastyle.scalariform.ReturnChecker" enabled="true"></check>
+  <check level="error" class="org.scalastyle.scalariform.NullChecker" enabled="true"></check>
+  <check level="error" class="org.scalastyle.scalariform.NoCloneChecker" enabled="true"></check>
+  <check level="error" class="org.scalastyle.scalariform.NoFinalizeChecker" enabled="true"></check>
+  <check level="error" class="org.scalastyle.scalariform.CovariantEqualsChecker" enabled="true"></check>
+  <check level="error" class="org.scalastyle.scalariform.StructuralTypeChecker" enabled="true"></check>
+  <check level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
     <parameters>
       <parameter name="regex"><![CDATA[println]]></parameter>
     </parameters>
   </check>
-  <check level="warning" class="org.scalastyle.scalariform.NumberOfTypesChecker" enabled="true">
+  <check level="error" class="org.scalastyle.scalariform.NumberOfTypesChecker" enabled="true">
     <parameters>
       <parameter name="maxTypes"><![CDATA[30]]></parameter>
     </parameters>
   </check>
-  <check level="warning" class="org.scalastyle.scalariform.CyclomaticComplexityChecker" enabled="true">
+  <check level="error" class="org.scalastyle.scalariform.CyclomaticComplexityChecker" enabled="true">
     <parameters>
       <parameter name="maximum"><![CDATA[10]]></parameter>
     </parameters>
   </check>
-  <check level="warning" class="org.scalastyle.scalariform.UppercaseLChecker" enabled="true"></check>
-  <check level="warning" class="org.scalastyle.scalariform.SimplifyBooleanExpressionChecker" enabled="true"></check>
-  <check level="warning" class="org.scalastyle.scalariform.IfBraceChecker" enabled="true">
+  <check level="error" class="org.scalastyle.scalariform.UppercaseLChecker" enabled="true"></check>
+  <check level="error" class="org.scalastyle.scalariform.SimplifyBooleanExpressionChecker" enabled="true"></check>
+  <check level="error" class="org.scalastyle.scalariform.IfBraceChecker" enabled="true">
     <parameters>
       <parameter name="singleLineAllowed"><![CDATA[true]]></parameter>
       <parameter name="doubleLineAllowed"><![CDATA[false]]></parameter>
     </parameters>
   </check>
-  <check level="warning" class="org.scalastyle.scalariform.MethodLengthChecker" enabled="true">
+  <check level="error" class="org.scalastyle.scalariform.MethodLengthChecker" enabled="true">
     <parameters>
       <parameter name="maxLength"><![CDATA[50]]></parameter>
     </parameters>
   </check>
-  <check level="warning" class="org.scalastyle.scalariform.MethodNamesChecker" enabled="true">
+  <check level="error" class="org.scalastyle.scalariform.MethodNamesChecker" enabled="true">
     <parameters>
       <parameter name="regex"><![CDATA[^[a-z][A-Za-z0-9]*$]]></parameter>
     </parameters>
   </check>
-  <check level="warning" class="org.scalastyle.scalariform.NumberOfMethodsInTypeChecker" enabled="true">
+  <check level="error" class="org.scalastyle.scalariform.NumberOfMethodsInTypeChecker" enabled="true">
     <parameters>
       <parameter name="maxMethods"><![CDATA[30]]></parameter>
     </parameters>
   </check>
-  <check level="warning" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" enabled="true"></check>
-  <check level="warning" class="org.scalastyle.file.NewLineAtEofChecker" enabled="true"></check>
-  <check level="warning" class="org.scalastyle.file.NoNewLineAtEofChecker" enabled="false"></check>
-  <check level="warning" class="org.scalastyle.scalariform.WhileChecker" enabled="false"></check>
-  <check level="warning" class="org.scalastyle.scalariform.VarFieldChecker" enabled="false"></check>
-  <check level="warning" class="org.scalastyle.scalariform.VarLocalChecker" enabled="false"></check>
-  <check level="warning" class="org.scalastyle.scalariform.RedundantIfChecker" enabled="false"></check>
-  <check level="warning" class="org.scalastyle.scalariform.TokenChecker" enabled="false">
+  <check level="error" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" enabled="true"></check>
+  <check level="error" class="org.scalastyle.file.NewLineAtEofChecker" enabled="true"></check>
+  <check level="error" class="org.scalastyle.file.NoNewLineAtEofChecker" enabled="false"></check>
+  <check level="error" class="org.scalastyle.scalariform.WhileChecker" enabled="false"></check>
+  <check level="error" class="org.scalastyle.scalariform.VarFieldChecker" enabled="false"></check>
+  <check level="error" class="org.scalastyle.scalariform.VarLocalChecker" enabled="false"></check>
+  <check level="error" class="org.scalastyle.scalariform.RedundantIfChecker" enabled="false"></check>
+  <check level="error" class="org.scalastyle.scalariform.TokenChecker" enabled="false">
     <parameters>
       <parameter name="regex"><![CDATA[println]]></parameter>
     </parameters>
   </check>
-  <check level="warning" class="org.scalastyle.scalariform.DeprecatedJavaChecker" enabled="true"></check>
-  <check level="warning" class="org.scalastyle.scalariform.EmptyClassChecker" enabled="true"></check>
-  <check level="warning" class="org.scalastyle.scalariform.ClassTypeParameterChecker" enabled="true">
+  <check level="error" class="org.scalastyle.scalariform.DeprecatedJavaChecker" enabled="true"></check>
+  <check level="error" class="org.scalastyle.scalariform.EmptyClassChecker" enabled="true"></check>
+  <check level="error" class="org.scalastyle.scalariform.ClassTypeParameterChecker" enabled="true">
     <parameters>
       <parameter name="regex"><![CDATA[^[A-Z_]$]]></parameter>
     </parameters>
   </check>
-  <check level="warning" class="org.scalastyle.scalariform.UnderscoreImportChecker" enabled="true"></check>
-  <check level="warning" class="org.scalastyle.scalariform.LowercasePatternMatchChecker" enabled="true"></check>
-  <check level="warning" class="org.scalastyle.scalariform.MultipleStringLiteralsChecker" enabled="true">
+  <check level="error" class="org.scalastyle.scalariform.UnderscoreImportChecker" enabled="true"></check>
+  <check level="error" class="org.scalastyle.scalariform.LowercasePatternMatchChecker" enabled="true"></check>
+  <check level="error" class="org.scalastyle.scalariform.MultipleStringLiteralsChecker" enabled="true">
     <parameters>
       <parameter name="allowed"><![CDATA[2]]></parameter>
       <parameter name="ignoreRegex"><![CDATA[^""$]]></parameter>
     </parameters>
   </check>
-  <check level="warning" class="org.scalastyle.scalariform.ImportGroupingChecker" enabled="true"></check>
+  <check level="error" class="org.scalastyle.scalariform.ImportGroupingChecker" enabled="true"></check>
 </scalastyle>


### PR DESCRIPTION
* Run `scalastyle` from the main directory
* Treat rule break as error, not as warning (all `warning`-level rules are ignored in workflow)
* Remove checking file header